### PR TITLE
Set action plan owner

### DIFF
--- a/app/assets/javascripts/modal_action_plan.js
+++ b/app/assets/javascripts/modal_action_plan.js
@@ -1,0 +1,10 @@
+function openModal(id_action_plan) {  
+  var modal = $('#action_plan_modal_' + id_action_plan);
+  var close = document.getElementById('close_symbol_' + id_action_plan);
+
+  modal.removeClass('hidden').addClass('modal');
+
+  close.onclick = function() {
+    modal.removeClass('modal').addClass('hidden');
+  };
+};

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -73,4 +73,10 @@
       }
     }
   }
+
+  &.options_action_plan {
+    padding: 3px 12px;
+    font-size: 12px;
+    margin-right: 0;
+  }
 }

--- a/app/assets/stylesheets/modal_action_plan.scss
+++ b/app/assets/stylesheets/modal_action_plan.scss
@@ -1,0 +1,32 @@
+.modal {
+  display: block;
+
+  &__content {
+    margin: auto;
+    border: 1.5px solid #888;
+    width: 65%;
+    box-shadow: 0 8px 16px 0 rgba(0, 0, 0, .2), 0 6px 20px 0 rgba(0, 0, 0, .19);
+  }
+
+  &__header {
+    padding: 2px 5px;
+    background-color: #888;
+  }
+
+  &__title {
+    font-size: 20px;
+    font-weight: bold;
+    margin-top: 0;
+    margin-bottom: 5px;
+  }
+
+  &__body {
+    padding: 2px 16px;
+  }
+
+  &__close {
+    cursor: pointer;
+    font-size: 25px;
+    margin-left: 95%;
+  }
+}

--- a/app/assets/stylesheets/retrospective.scss
+++ b/app/assets/stylesheets/retrospective.scss
@@ -72,6 +72,11 @@
       border-color: green;
       border-radius: 3px;
     }
+
+    &.owner {
+      width: 50%;
+      text-align: center;
+    }
   }
 }
 

--- a/app/controllers/retrospectives_controller.rb
+++ b/app/controllers/retrospectives_controller.rb
@@ -8,7 +8,10 @@ class RetrospectivesController < ApplicationController
     @to_mention = []
     @to_discuss = []
     @action_plans = []
-    set_session_params(@to_mention, @to_discuss, @action_plans)
+    @cant_action_plans = 0
+    @action_plan_owners = {}
+    set_session_params(@to_mention, @to_discuss, @action_plans,
+                       @cant_action_plans, @action_plan_owners)
   end
 
   def post_mention_topics
@@ -36,14 +39,29 @@ class RetrospectivesController < ApplicationController
     incoming_plan = params[:action_plan]
     @action_plans << incoming_plan
     @new_action_plan = incoming_plan
+    @cant_action_plans += 1
+    session[:cant_action_plans] = @cant_action_plans
+  end
+
+  def set_action_plan_owner
+    return if params[:action_plan_owner].blank?
+
+    action_plans_owners_params
+    incoming_owner = params[:action_plan_owner]
+    @id_action_plan = params[:id_ac]
+    @action_plan_owners[@id_action_plan] = incoming_owner
+    @new_owner = incoming_owner
   end
 
   private
 
-  def set_session_params(to_mention, to_discuss, action_plans)
+  def set_session_params(to_mention, to_discuss, action_plans,
+                         cant_action_plans, action_plan_owners)
     session[:array_to_mention] = to_mention
     session[:array_to_discuss] = to_discuss
     session[:array_action_plans] = action_plans
+    session[:cant_action_plans] = cant_action_plans
+    session[:array_owners] = action_plan_owners
   end
 
   def mention_params
@@ -59,5 +77,12 @@ class RetrospectivesController < ApplicationController
   def action_plans_params
     @action_plans = session[:array_action_plans]
     @new_action_plan = nil
+    @cant_action_plans = session[:cant_action_plans]
+  end
+
+  def action_plans_owners_params
+    @action_plan_owners = session[:array_owners]
+    @new_owner = nil
+    @cant_action_plans = session[:cant_action_plans]
   end
 end

--- a/app/views/retrospectives/_action_plan_item.html.erb
+++ b/app/views/retrospectives/_action_plan_item.html.erb
@@ -1,0 +1,18 @@
+<li class='topics list plan'> 
+  <%= @action_plans.last %>
+  <%= button_tag 'Options', class: 'button_app options_action_plan', onclick: "openModal(#{@cant_action_plans})" %>
+</li>
+
+<div id="action_plan_modal_<%= @cant_action_plans %>" class="hidden">
+  <div class="modal__content">
+    <div class="modal__header">
+      <span id='close_symbol_<%= @cant_action_plans %>' class="modal__close">&times;</span>
+      <p class='modal__title'>Owner</p>
+    </div>
+    <div id="modal_body_<%= @cant_action_plans %>" class="modal__body">
+      <%= form_tag set_action_plan_owner_retrospective_path(id_ac: @cant_action_plans), remote: true do %>
+        <%= text_field_tag :action_plan_owner, nil, placeholder: 'Set action plan owner...', class: 'topics input', id: "owner_input_#{@cant_action_plans}", required: true %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/retrospectives/_action_plan_owner.html.erb
+++ b/app/views/retrospectives/_action_plan_owner.html.erb
@@ -1,0 +1,3 @@
+<li class='topics list owner'>
+  <%= @action_plan_owners.values.last %>
+</li>

--- a/app/views/retrospectives/_action_plans_item.html.erb
+++ b/app/views/retrospectives/_action_plans_item.html.erb
@@ -1,3 +1,0 @@
-<li class='topics list plan'> 
-  <%= @action_plans.last %>
-</li>

--- a/app/views/retrospectives/add_action_plan.js.erb
+++ b/app/views/retrospectives/add_action_plan.js.erb
@@ -1,4 +1,4 @@
 <% if @new_action_plan %>
-  $('#action_plans_list').append("<%=j render('action_plans_item') %>");
+  $('#action_plans_list').append("<%=j render('action_plan_item') %>");
   $('#action_plan_input').val('');
 <% end %>

--- a/app/views/retrospectives/new.html.erb
+++ b/app/views/retrospectives/new.html.erb
@@ -1,5 +1,6 @@
 <% content_for :add_scripts do %>
   <%= javascript_include_tag 'timer' %>
+  <%= javascript_include_tag 'modal_action_plan' %>
 <% end %>
 
 <% content_for :add_to_header do %>

--- a/app/views/retrospectives/set_action_plan_owner.js.erb
+++ b/app/views/retrospectives/set_action_plan_owner.js.erb
@@ -1,0 +1,4 @@
+<% if @new_owner %>
+  $("<%="#modal_body_#{@id_action_plan}"%>").append("<%=j render('action_plan_owner') %>");
+  $("<%="#owner_input_#{@id_action_plan}"%>").removeClass('input').addClass('hidden');
+<% end %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -14,4 +14,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
-Rails.application.config.assets.precompile += %w[timer.js]
+Rails.application.config.assets.precompile += %w[timer.js modal_action_plan.js]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,6 @@ Rails.application.routes.draw do
     post :post_mention_topics
     post :post_discuss_topics
     post :add_action_plan
+    post :set_action_plan_owner
   end
 end


### PR DESCRIPTION
Create `Options` button in each action plan to open an onclick modal to set the owner.
Update the `retrospective_controller`, adding a new endpoint to set the owners of the action plans and setting in the session.
Update the `scss` files and add a new one for the modal.
Update the views and create the one that responds to the controller.

I'll add the missing tests in another commit.